### PR TITLE
Enable the use of a home directory in the s4c

### DIFF
--- a/bin/s4c
+++ b/bin/s4c
@@ -45,6 +45,11 @@ while [ "$(pwd)" != "/" ] && [ ! -d ".repo" ]; do
 	cd ..
 done
 
+# Find the container home directory
+if [ -d "$HOME/.s4c-home" ]; then
+	CONTAINER_HOME="--env HOME -v $(realpath -e "$HOME/.s4c-home"):$HOME:z"
+fi
+
 if [ "$(pwd)" = "/" ]; then
 	cd "${CURDIR}"
 	WORKDIR="."
@@ -58,6 +63,7 @@ elif [ $# -gt 0 ]; then
 		"${SET_USERID}" \
 		--hostname=s4c \
 		-v "$(pwd):/host:z" \
+		${CONTAINER_HOME} \
 		--workdir="/host/${WORKDIR}" \
 		"${CONTAINER}" \
 		"$@"
@@ -67,6 +73,7 @@ else
 		"${SET_USERID}" \
 		--hostname=s4c \
 		-v "$(pwd):/host:z" \
+		${CONTAINER_HOME} \
 		--workdir="/host/${WORKDIR}" \
 		"${CONTAINER}" \
 		bash


### PR DESCRIPTION
This adds a re-usable dedicated home directory that can be re-used
across container invocations.

The actual user-home isn't used here as this home tends to be used for
build tools installed in the home directory that depend on the target
distribution, so we avoid the host and container from conflicting in the
versions of these tools they wish installed.

Signed-off-by: Curtis Millar <curtis@curtism.me>